### PR TITLE
Fix linking with newer gcc versions (undefined symbol: dlsym)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROGNAME=runit-docker
 all: $(PROGNAME).so
 
 %.so: %.c
-	gcc -shared $(CFLAGS) $(LDFLAGS) -o $@ $^
+	gcc -shared $(CFLAGS) $^ $(LDFLAGS) -o $@
 
 install: runit-docker.so
 	mkdir -p $(DESTDIR)/usr/sbin

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ all: $(PROGNAME).so
 
 install: runit-docker.so
 	mkdir -p $(DESTDIR)/sbin
-	mkdir -p $(DESTDIR)/lib
+	mkdir -p $(DESTDIR)/usr/lib/runit-docker/
 	install -m 755 $(PROGNAME) $(DESTDIR)/sbin/
-	install -m 755 $(PROGNAME).so $(DESTDIR)/lib/
+	install -m 755 $(PROGNAME).so $(DESTDIR)/usr/lib/runit-docker/
 
 clean:
 	$(RM) $(PROGNAME).so

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: $(PROGNAME).so
 	gcc -shared $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 install: runit-docker.so
-	mkdir -p $(DESTDIR)/sbin
+	mkdir -p $(DESTDIR)/usr/sbin
 	mkdir -p $(DESTDIR)/usr/lib/runit-docker/
 	install -m 755 $(PROGNAME) $(DESTDIR)/sbin/
 	install -m 755 $(PROGNAME).so $(DESTDIR)/usr/lib/runit-docker/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-CFLAGS=-std=c99 -Wall -O2 -fPIC -D_POSIX_SOURCE -D_GNU_SOURCE
-LDLIBS=-ldl
+CFLAGS+=-std=c99 -Wall -O2 -fPIC -D_POSIX_SOURCE -D_GNU_SOURCE
+LDFLAGS+=-ldl
 
 PROGNAME=runit-docker
 
 all: $(PROGNAME).so
 
 %.so: %.c
-	gcc -shared $(CFLAGS) $(LDLIBS) -o $@ $^
+	gcc -shared $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 install: runit-docker.so
 	mkdir -p $(DESTDIR)/sbin

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: $(PROGNAME).so
 install: runit-docker.so
 	mkdir -p $(DESTDIR)/usr/sbin
 	mkdir -p $(DESTDIR)/usr/lib/runit-docker/
-	install -m 755 $(PROGNAME) $(DESTDIR)/sbin/
+	install -m 755 $(PROGNAME) $(DESTDIR)/usr/sbin/
 	install -m 755 $(PROGNAME).so $(DESTDIR)/usr/lib/runit-docker/
 
 clean:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Under the hood, `runit-docker` translates `SIGTERM` and `SIGINT` to `SIGHUP`.
 ## Usage
 
 * Build with `make`, install with `make install`.
-* Add `CMD ["/sbin/runit-docker"]` to your `Dockerfile`.
+* Add `CMD ["/usr/sbin/runit-docker"]` to your `Dockerfile`.
 * Run `debian/rules clean build binary` to build a Debian package.
 
 ## Author

--- a/runit-docker
+++ b/runit-docker
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LD_PRELOAD=/lib/runit-docker.so
+export LD_PRELOAD=/usr/lib/runit-docker/runit-docker.so
 exec runsvdir /etc/service

--- a/runit-docker
+++ b/runit-docker
@@ -1,4 +1,9 @@
 #!/bin/sh
 
 export LD_PRELOAD="/usr/lib/runit-docker/runit-docker.so $LD_PRELOAD"
-exec runsvdir /etc/service
+
+if [ -n "$1" ]; then
+    exec "$@"
+else
+    exec runsvdir /etc/service
+fi

--- a/runit-docker
+++ b/runit-docker
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-export LD_PRELOAD=/usr/lib/runit-docker/runit-docker.so
+export LD_PRELOAD="/usr/lib/runit-docker/runit-docker.so $LD_PRELOAD"
 exec runsvdir /etc/service


### PR DESCRIPTION
If built against newer gcc versions (like 10.2 under Debian Bullseye), this library was no longer working, with errors like:

```
runsvdir: symbol lookup error: /usr/lib/runit-docker/runit-docker.so: undefined symbol: dlsym
```

This is due to the newer versions of gcc being pickier about the argument ordering, so the `-ldl` flag needs to come later.

This PR actually includes all of the changes from @onlyjob in #1 too, but with two additional fixes:

1. This gcc fix for newer gcc versions.
2. A fix to @onlyjob's initial work to install the bin in `/usr/sbin`.

If you would like any of these commits separated, let me know. But since I'm not sure this library is being actively maintained anymore (which is totally fine), I mainly just wanted to create this PR for awareness in case other users run into this with newer gcc versions. Thanks!